### PR TITLE
fix bug related to contig name formatting

### DIFF
--- a/sourceCode/ngs_te_mapper2.py
+++ b/sourceCode/ngs_te_mapper2.py
@@ -207,7 +207,10 @@ def main():
             thread=args.thread,
         )
     te_bed = os.path.join(mask_ref_dir, os.path.basename(ref) + ".bed")
-    gff3tobed(te_gff, te_bed)
+    if te_gff is not None:
+        gff3tobed(te_gff, te_bed)
+    else:
+        te_bed = None
     if args.mapper == "bwa":
         subprocess.call(["bwa", "index", ref_masked])
         subprocess.call(["bwa", "index", library])


### PR DESCRIPTION
- The previous version of ngs_te_mapper2 requires the contig name in the reference genome to include "chr", the new update removes this requirement.
- The update also addresses a bug when the reference genome doesn't contain any TE sequences.